### PR TITLE
fix: 修复在钉钉小程序里无限刷新的问题

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -7,6 +7,7 @@ import {
   updateComponent2Status,
   getIdFromAppxInstance,
   instanceKeyPropNames,
+  shallowCompare,
 } from './utils.js';
 
 import HandlersController from './handlers.js';
@@ -323,7 +324,14 @@ export function functionalMiniElement<TProps>(
         'deriveDataFromProps',
         anyContext,
         function hookDeriveDataFromProps(this: any, nextProps) {
-          if (this.props && this.props === nextProps) return; // 可能是setData触发的，不要死循环了
+          if (this.props && this.props === nextProps) {
+            // 可能是setData触发的，不要死循环了
+            return;
+          } else {
+            if (shallowCompare(this.props, nextProps, ['$slots'])) {
+              return;
+            }
+          }
           return dispatchNewProps(this, nextProps);
         },
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export const timeEnd = (label?: string) => {
 };
 
 //@ts-expect-error
-export const shallowCompare = (obj1, obj2) => {
+export const shallowCompare = (obj1, obj2, skipKey?: string[]) => {
   if (obj1 === obj2) return true;
   if (typeof obj1 !== typeof obj2) return false;
   if (typeof obj1 !== 'object' || typeof obj2 !== 'object') return false;
@@ -36,7 +36,9 @@ export const shallowCompare = (obj1, obj2) => {
   if (Array.isArray(obj1) || Array.isArray(obj2)) return false;
   if (Object.keys(obj1).length !== Object.keys(obj2).length) return false;
   for (const key in obj1) {
-    if (obj1[key] !== obj2[key]) return false;
+    if (obj1[key] !== obj2[key] && (!skipKey || skipKey.indexOf(key) === -1)) {
+      return false;
+    }
   }
   return true;
 };

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -676,4 +676,25 @@ describe('component - common and alipay', () => {
     expect(instance.data).toEqual({ foo: '3' });
     expect(instance.callMethod('getCount')).toEqual(3);
   });
+
+  test('忽略 props 里 $slots 的更新', async () => {
+    const C = function (props) {
+      const [count, setCount] = useState(0);
+      useEffect(() => {
+        setCount((o) => o + 1);
+      }, [props]);
+      return { foo: String(count) };
+    };
+    const instance = mountAlipayComponent(alipayComponent(C));
+    expect(instance.data).toEqual({ foo: '1' });
+    instance.updateProps({
+      $slots: 1,
+    });
+    await delay(10);
+    expect(instance.data).toEqual({ foo: '2' });
+    instance.updateProps({
+      $slots: 2,
+    });
+    expect(instance.data).toEqual({ foo: '2' });
+  });
 });


### PR DESCRIPTION
father

```xml
<button size="default" type="primary" onTap="toSon">点击进入子页面</button>
<ant-popup
  visible="{{ showFilter }}"
  height="{{ 450 }}"
  
  position="bottom">
    <view>
    
    <button class="cu-btn margin-left-sm margin-top-sm bg-olive" onTap="query">查询</button>
  </view>
</ant-popup>
```


```js
Page({
  data: {},
  onLoad() {},
  toSon(){
    my.navigateTo({
      url:"/pages/test/son/son"
    })
  }
});
```


child 

```xml
<button size="default" type="primary" onTap="backToFather">回到父页面</button>
```

```
Page({
  data: {},
  onLoad() {},
  backToFather(){
    let pages = getCurrentPages();
    let last =  pages[pages.length-2];
    last.setData({
      'a':1
    })
    my.navigateBack({
      delta: 1,
    })
  }
});

```